### PR TITLE
fix Next.js build by wrapping search params in Suspense

### DIFF
--- a/src/app/reader/page.tsx
+++ b/src/app/reader/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useMemo, useRef } from "react";
+import { Suspense, useMemo, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import Flipbook from "@/components/Flipbook";
 import { usePdfImages } from "@/hooks/usePdfImages";
 
-export default function ReaderPage() {
+function ReaderContent() {
     const params = useSearchParams();
     const pdf = params.get("file") ?? "/cosmogonia_pai_tavytera.pdf";
     const containerRef = useRef<HTMLDivElement | null>(null);
@@ -42,5 +42,13 @@ export default function ReaderPage() {
                 Pantalla completa
             </button>
         </div>
+    );
+}
+
+export default function ReaderPage() {
+    return (
+        <Suspense fallback={<div className="p-8 text-center text-neutral-500">Cargando…</div>}>
+            <ReaderContent />
+        </Suspense>
     );
 }

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -1,11 +1,13 @@
 // Carga perezosa de pdf.js usando el build legacy (evita módulo ESM del worker)
-let _pdfjs: any = null;
+import type { PDFPageProxy } from "pdfjs-dist/types/src/display/api";
+
+let _pdfjs: typeof import("pdfjs-dist") | null = null;
 
 export async function loadPdfJs() {
     if (_pdfjs) return _pdfjs;
 
     // Import legacy build para compatibilidad amplia
-    const lib: any = await import("pdfjs-dist/legacy/build/pdf");
+    const lib = await import("pdfjs-dist/legacy/build/pdf");
 
     // Apuntar al worker auto-hosteado en /public
     lib.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.js";
@@ -15,7 +17,7 @@ export async function loadPdfJs() {
 }
 
 export async function renderPageToBlobURL(
-    page: any,
+    page: PDFPageProxy,
     targetWidth: number
 ): Promise<{ url: string; width: number; height: number }> {
     const viewport = page.getViewport({ scale: 1 });


### PR DESCRIPTION
## Summary
- wrap Reader page content with `<Suspense>` to allow useSearchParams during prerender
- tighten pdf.js helper typings to avoid `any` usage

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68afe38cd4208329a1fb868498f7dff3