### PR TITLE
Add reader title and orientation notice

### DIFF
--- a/src/app/reader/page.tsx
+++ b/src/app/reader/page.tsx
@@ -28,7 +28,9 @@ function ReaderContent() {
     };
 
     return (
-        <div className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-100 p-2">
+        <div className="flex min-h-screen w-full flex-col items-center bg-neutral-100 p-2">
+            <h1 className="mt-2 text-2xl font-bold">Cosmogonía Paĩ Tavyterã</h1>
+            <p className="mb-4 text-sm text-neutral-600">Poner el celular en horizontal para mejor visualización</p>
             <div ref={containerRef} className="flex w-full justify-center">
                 {error && <div className="p-6 text-center text-red-600">{error}</div>}
                 {loading && <div className="p-8 text-center text-neutral-500">Procesando páginas…</div>}

--- a/src/components/Flipbook.tsx
+++ b/src/components/Flipbook.tsx
@@ -22,8 +22,16 @@ export default function Flipbook({ pages }: Props) {
     const [size, setSize] = useState<{ w: number; h: number }>(() => {
         const first = pages[0];
         const ratio = first.height / first.width;
-        const w = Math.min(900, first.width);
-        return { w, h: Math.round(w * ratio) };
+        let w = Math.min(900, first.width);
+        let h = Math.round(w * ratio);
+        if (typeof window !== "undefined") {
+            const maxH = Math.floor(window.innerHeight * 0.7);
+            if (h > maxH) {
+                h = maxH;
+                w = Math.round(h / ratio);
+            }
+        }
+        return { w, h };
     });
 
     useEffect(() => {
@@ -31,8 +39,14 @@ export default function Flipbook({ pages }: Props) {
             const first = pages[0];
             const ratio = first.height / first.width;
             const maxW = Math.min(first.width, Math.floor(window.innerWidth * 0.9));
-            const w = Math.min(900, Math.max(420, maxW));
-            setSize({ w, h: Math.round(w * ratio) });
+            const maxH = Math.floor(window.innerHeight * 0.7);
+            let w = Math.min(900, Math.max(420, maxW));
+            let h = Math.round(w * ratio);
+            if (h > maxH) {
+                h = maxH;
+                w = Math.round(h / ratio);
+            }
+            setSize({ w, h });
         };
         onResize();
         window.addEventListener("resize", onResize);
@@ -75,7 +89,7 @@ export default function Flipbook({ pages }: Props) {
                                 width={p.width}
                                 height={p.height}
                                 alt={idx === 0 ? "Portada" : `Página ${idx}`}
-                                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                                style={{ width: "100%", height: "100%", objectFit: "contain" }}
                             />
                         </article>
                     ))}


### PR DESCRIPTION
## Summary
- add "Cosmogonía Paĩ Tavyterã" title and horizontal-view hint
- render pages with `object-fit: contain` and avoid vertical centering to prevent mobile zoom
- cap flipbook height to screen so all pages display fully

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68afe5ee0ba88329b2278309f52991af