### PR TITLE
feat: improve mobile reader and limit pages

### DIFF
--- a/src/app/reader/page.tsx
+++ b/src/app/reader/page.tsx
@@ -9,6 +9,7 @@ export default function Page() {
     const [error, setError] = useState<string | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
     const [containerWidth, setContainerWidth] = useState(0);
+    const [containerHeight, setContainerHeight] = useState(0);
 
     useEffect(() => {
         const urls = Array.from({ length: 38 }, (_, i) => `/images/Mesa-${String(i + 1).padStart(2, "0")}.png`);
@@ -31,15 +32,16 @@ export default function Page() {
     }, []);
 
     useEffect(() => {
-        const updateWidth = () => {
+        const updateSize = () => {
             setContainerWidth(containerRef.current?.clientWidth ?? window.innerWidth);
+            setContainerHeight(containerRef.current?.clientHeight ?? window.innerHeight);
         };
-        updateWidth();
-        window.addEventListener("resize", updateWidth);
-        document.addEventListener("fullscreenchange", updateWidth);
+        updateSize();
+        window.addEventListener("resize", updateSize);
+        document.addEventListener("fullscreenchange", updateSize);
         return () => {
-            window.removeEventListener("resize", updateWidth);
-            document.removeEventListener("fullscreenchange", updateWidth);
+            window.removeEventListener("resize", updateSize);
+            document.removeEventListener("fullscreenchange", updateSize);
         };
     }, []);
 
@@ -59,7 +61,11 @@ export default function Page() {
             {error && <div className="p-6 text-center text-red-600">{error}</div>}
             {!pages && !error && <div className="p-8 text-center text-neutral-500">Cargando páginas…</div>}
             {pages && pages.length > 0 && (
-                <Flipbook pages={pages} containerWidth={containerWidth} />
+                <Flipbook
+                    pages={pages}
+                    containerWidth={containerWidth}
+                    containerHeight={containerHeight}
+                />
             )}
             <button
                 onClick={enterFullscreen}

--- a/src/app/reader/page.tsx
+++ b/src/app/reader/page.tsx
@@ -8,9 +8,10 @@ export default function Page() {
     const [pages, setPages] = useState<PageImage[] | null>(null);
     const [error, setError] = useState<string | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
+    const [containerWidth, setContainerWidth] = useState(0);
 
     useEffect(() => {
-        const urls = Array.from({ length: 40 }, (_, i) => `/images/Mesa-${String(i + 1).padStart(2, "0")}.png`);
+        const urls = Array.from({ length: 38 }, (_, i) => `/images/Mesa-${String(i + 1).padStart(2, "0")}.png`);
         Promise.all(
             urls.map(
                 (url) =>
@@ -29,6 +30,19 @@ export default function Page() {
             });
     }, []);
 
+    useEffect(() => {
+        const updateWidth = () => {
+            setContainerWidth(containerRef.current?.clientWidth ?? window.innerWidth);
+        };
+        updateWidth();
+        window.addEventListener("resize", updateWidth);
+        document.addEventListener("fullscreenchange", updateWidth);
+        return () => {
+            window.removeEventListener("resize", updateWidth);
+            document.removeEventListener("fullscreenchange", updateWidth);
+        };
+    }, []);
+
     const enterFullscreen = () => {
         const el = containerRef.current;
         if (!el) return;
@@ -38,27 +52,21 @@ export default function Page() {
     };
 
     return (
-        <div className="min-h-screen w-full">
-            <main className="mx-auto max-w-6xl px-2 pb-16 pt-6">
-                <div
-                    ref={containerRef}
-                    className="mx-auto flex w-full justify-center rounded-2xl border bg-white p-2 shadow-sm"
-                >
-                    {error && <div className="p-6 text-center text-red-600">{error}</div>}
-                    {!pages && !error && (
-                        <div className="p-8 text-center text-neutral-500">Cargando páginas…</div>
-                    )}
-                    {pages && pages.length > 0 && <Flipbook pages={pages} />}
-                </div>
-                <div className="mt-4 flex justify-center">
-                    <button
-                        onClick={enterFullscreen}
-                        className="rounded-full bg-indigo-600 px-5 py-2 text-white shadow hover:bg-indigo-500"
-                    >
-                        Pantalla completa
-                    </button>
-                </div>
-            </main>
+        <div
+            ref={containerRef}
+            className="relative flex h-screen w-screen flex-col items-center justify-center overflow-hidden"
+        >
+            {error && <div className="p-6 text-center text-red-600">{error}</div>}
+            {!pages && !error && <div className="p-8 text-center text-neutral-500">Cargando páginas…</div>}
+            {pages && pages.length > 0 && (
+                <Flipbook pages={pages} containerWidth={containerWidth} />
+            )}
+            <button
+                onClick={enterFullscreen}
+                className="absolute bottom-4 rounded-full bg-indigo-600 px-5 py-2 text-white shadow hover:bg-indigo-500"
+            >
+                Pantalla completa
+            </button>
         </div>
     );
 }

--- a/src/app/reader/page.tsx
+++ b/src/app/reader/page.tsx
@@ -54,7 +54,7 @@ export default function Page() {
     return (
         <div
             ref={containerRef}
-            className="relative flex h-screen w-screen flex-col items-center justify-center overflow-hidden"
+            className="relative flex h-screen w-screen flex-col items-center justify-start overflow-y-auto"
         >
             {error && <div className="p-6 text-center text-red-600">{error}</div>}
             {!pages && !error && <div className="p-8 text-center text-neutral-500">Cargando páginas…</div>}
@@ -63,7 +63,7 @@ export default function Page() {
             )}
             <button
                 onClick={enterFullscreen}
-                className="absolute bottom-4 rounded-full bg-indigo-600 px-5 py-2 text-white shadow hover:bg-indigo-500"
+                className="fixed bottom-4 left-1/2 -translate-x-1/2 transform rounded-full bg-indigo-600 px-5 py-2 text-white shadow hover:bg-indigo-500"
             >
                 Pantalla completa
             </button>

--- a/src/components/Flipbook.tsx
+++ b/src/components/Flipbook.tsx
@@ -9,6 +9,7 @@ const ReactPageFlip = dynamic(() => import("react-pageflip"), { ssr: false }) as
 type Props = {
     pages: PageImage[];
     containerWidth?: number;
+    containerHeight?: number;
 };
 
 interface FlipBookHandle {
@@ -18,22 +19,20 @@ interface FlipBookHandle {
     };
 }
 
-export default function Flipbook({ pages, containerWidth }: Props) {
+export default function Flipbook({ pages, containerWidth, containerHeight }: Props) {
     const bookRef = useRef<FlipBookHandle | null>(null);
 
     const computeSize = useCallback(() => {
         const first = pages[0];
-        const ratio = first.height / first.width;
-        const screenW =
-            containerWidth && containerWidth > 0
-                ? containerWidth
-                : typeof window !== "undefined"
-                ? window.innerWidth
-                : first.width * 2;
-        const w = Math.floor(screenW / 2);
+        const ratio = first.height / first.width; // height / width of a single page
+        const screenW = containerWidth && containerWidth > 0 ? containerWidth : typeof window !== "undefined" ? window.innerWidth : first.width * 2;
+        const screenH = containerHeight && containerHeight > 0 ? containerHeight : typeof window !== "undefined" ? window.innerHeight : first.height;
+        const wByWidth = Math.floor(screenW / 2);
+        const wByHeight = Math.floor(screenH / ratio);
+        const w = Math.min(wByWidth, wByHeight);
         const h = Math.round(w * ratio);
         return { w, h };
-    }, [pages, containerWidth]);
+    }, [pages, containerWidth, containerHeight]);
 
     const [size, setSize] = useState<{ w: number; h: number }>(() => computeSize());
 

--- a/src/components/Flipbook.tsx
+++ b/src/components/Flipbook.tsx
@@ -30,14 +30,8 @@ export default function Flipbook({ pages, containerWidth }: Props) {
                 : typeof window !== "undefined"
                 ? window.innerWidth
                 : first.width * 2;
-        const screenH = typeof window !== "undefined" ? window.innerHeight : first.height;
-        let w = Math.floor(screenW / 2);
-        let h = Math.round(w * ratio);
-        const maxH = Math.floor(screenH);
-        if (h > maxH) {
-            h = maxH;
-            w = Math.round(h / ratio);
-        }
+        const w = Math.floor(screenW / 2);
+        const h = Math.round(w * ratio);
         return { w, h };
     }, [pages, containerWidth]);
 
@@ -53,7 +47,7 @@ export default function Flipbook({ pages, containerWidth }: Props) {
     }, [computeSize]);
 
     return (
-        <div className="flex h-full w-full flex-col items-center justify-center">
+        <div className="flex h-full w-full flex-col items-center justify-start">
             <ReactPageFlip
                 ref={bookRef}
                 width={size.w}

--- a/src/components/Flipbook.tsx
+++ b/src/components/Flipbook.tsx
@@ -33,7 +33,7 @@ export default function Flipbook({ pages, containerWidth }: Props) {
         const screenH = typeof window !== "undefined" ? window.innerHeight : first.height;
         let w = Math.floor(screenW / 2);
         let h = Math.round(w * ratio);
-        const maxH = Math.floor(screenH * 0.9);
+        const maxH = Math.floor(screenH);
         if (h > maxH) {
             h = maxH;
             w = Math.round(h / ratio);
@@ -53,61 +53,59 @@ export default function Flipbook({ pages, containerWidth }: Props) {
     }, [computeSize]);
 
     return (
-        <div className="flex w-full justify-center">
-            <div className="max-w-full py-3">
-                <ReactPageFlip
-                    ref={bookRef}
-                    width={size.w}
-                    height={size.h}
-                    showCover
-                    usePortrait={false}
-                    flippingTime={700}
-                    maxShadowOpacity={0.5}
-                    className="flipbook"
-                    style={{}}
-                    startPage={0}
-                    size="fixed"
-                    minWidth={120}
-                    minHeight={120}
-                    maxWidth={900}
-                    maxHeight={1200}
-                    drawShadow={true}
-                    useMouseEvents={true}
-                    clickEventForward={true}
-                    swipeDistance={30}
-                    startZIndex={0}
-                    autoSize={false}
-                    mobileScrollSupport={true}
-                    showPageCorners={true}
-                    disableFlipByClick={false}
-                >
-                    {pages.map((p, idx) => (
-                        <article key={idx} className="page shadow">
-                            <img
-                                src={p.url}
-                                width={p.width}
-                                height={p.height}
-                                alt={idx === 0 ? "Portada" : `Página ${idx}`}
-                                style={{ width: "100%", height: "100%", objectFit: "contain" }}
-                            />
-                        </article>
-                    ))}
-                </ReactPageFlip>
+        <div className="flex h-full w-full flex-col items-center justify-center">
+            <ReactPageFlip
+                ref={bookRef}
+                width={size.w}
+                height={size.h}
+                showCover
+                usePortrait={false}
+                flippingTime={700}
+                maxShadowOpacity={0.5}
+                className="flipbook"
+                style={{}}
+                startPage={0}
+                size="fixed"
+                minWidth={120}
+                minHeight={120}
+                maxWidth={900}
+                maxHeight={1200}
+                drawShadow={true}
+                useMouseEvents={true}
+                clickEventForward={true}
+                swipeDistance={30}
+                startZIndex={0}
+                autoSize={false}
+                mobileScrollSupport={true}
+                showPageCorners={true}
+                disableFlipByClick={false}
+            >
+                {pages.map((p, idx) => (
+                    <article key={idx} className="page shadow">
+                        <img
+                            src={p.url}
+                            width={p.width}
+                            height={p.height}
+                            alt={idx === 0 ? "Portada" : `Página ${idx}`}
+                            style={{ width: "100%", height: "100%", objectFit: "contain" }}
+                        />
+                    </article>
+                ))}
+            </ReactPageFlip>
 
-                <div className="mt-4 flex items-center justify-center gap-4">
-                    <button
-                        className="flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-2 text-white shadow hover:bg-indigo-500"
-                        onClick={() => bookRef.current?.pageFlip().flipPrev()}
-                    >
-                        ◀︎ <span className="hidden sm:inline">Anterior</span>
-                    </button>
-                    <button
-                        className="flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-2 text-white shadow hover:bg-indigo-500"
-                        onClick={() => bookRef.current?.pageFlip().flipNext()}
-                    >
-                        <span className="hidden sm:inline">Siguiente</span> ▶︎
-                    </button>
-                </div>
+            <div className="mt-4 flex items-center justify-center gap-4">
+                <button
+                    className="flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-2 text-white shadow hover:bg-indigo-500"
+                    onClick={() => bookRef.current?.pageFlip().flipPrev()}
+                >
+                    ◀︎ <span className="hidden sm:inline">Anterior</span>
+                </button>
+                <button
+                    className="flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-2 text-white shadow hover:bg-indigo-500"
+                    onClick={() => bookRef.current?.pageFlip().flipNext()}
+                >
+                    <span className="hidden sm:inline">Siguiente</span> ▶︎
+                </button>
             </div>
 
             <style jsx>{`


### PR DESCRIPTION
## Summary
- make `/reader` mobile-first
- load only 38 pages instead of 40
- resize pages on orientation change and fullscreen so content fills the viewport
- ensure reader layout occupies the entire screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b1f12981d88329b78e6e78e92af172